### PR TITLE
Adding version key to manifest.json

### DIFF
--- a/custom_components/ltss/manifest.json
+++ b/custom_components/ltss/manifest.json
@@ -1,5 +1,6 @@
 {
     "domain": "ltss",
+    "version": "1.0.0",
     "name": "Long Time State Storage (LTSS)",
     "documentation": "https://github.com/freol35241/ltss",
     "requirements": [


### PR DESCRIPTION
Since ltss has been quite stable for a while now, the version is put at 1.0.0. I dont foresee any major changes unless anything changes from HAs side.