### PR TITLE
[WIP] added LITE version (deactivate TimescaleDB and/or Postgis usage)

### DIFF
--- a/custom_components/ltss/models.py
+++ b/custom_components/ltss/models.py
@@ -15,6 +15,7 @@ from sqlalchemy.schema import Index
 from sqlalchemy.dialects.postgresql import JSONB
 from geoalchemy2 import Geometry
 from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import column_property
 
 # SQLAlchemy Schema
 # pylint: disable=invalid-name
@@ -32,24 +33,39 @@ class LTSS(Base):  # type: ignore
     entity_id = Column(String(255))
     state = Column(String(255), index=True)
     attributes = Column(JSONB)
-    location = Column(Geometry('POINT', srid=4326))
+    location = None
 
-    @staticmethod
-    def from_event(event):
+    @classmethod
+    def activate_location_handling(cls):
+        """
+        Method to activate proper Postgis handling of location.
+
+        After activation, this cannot be deactivated (due to how the underlying SQLAlchemy ORM works).
+        """
+        cls.location = column_property(Column(Geometry('POINT', srid=4326)))
+
+    @classmethod
+    def from_event(cls, event):
         """Create object from a state_changed event."""
         entity_id = event.data["entity_id"]
         state = event.data.get("new_state")
 
         attrs = dict(state.attributes)
-        lat = attrs.pop('latitude', None)
-        lon = attrs.pop('longitude', None)
+
+        location = None
+
+        if cls.location:  # if the additional column exists, use Postgis' Geometry/Point data structure
+            lat = attrs.pop('latitude', None)
+            lon = attrs.pop('longitude', None)
+
+            location = f'SRID=4326;POINT({lon} {lat})' if lon and lat else None
 
         row = LTSS(
             entity_id=entity_id,
             time=event.time_fired,
             state=state.state,
             attributes=attrs,
-            location=f'SRID=4326;POINT({lon} {lat})' if lon and lat else None
+            location=location
         )
 
         return row

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,7 @@
+docker==5.0.3
+GeoAlchemy2==0.10.2
+homeassistant==2022.2.6
+psycopg2==2.9.3
+pytest-docker==0.10.3
+pytest==7.0.1
+SQLAlchemy==1.4.31

--- a/tests/test_databases.py
+++ b/tests/test_databases.py
@@ -1,0 +1,127 @@
+import time
+from time import sleep
+
+import docker as docker
+import pytest
+from sqlalchemy import text
+
+from custom_components.ltss import LTSS_DB, LTSS, MissingExtensionError
+
+
+class TestDBSetup:
+    @pytest.fixture(autouse=True)
+    def reset_LTSS(self):
+        # needed because the tests might change the underlying SQLAlchemy models and that needs to be reset
+        cols = [col for col in LTSS.__table__._columns if col.name == 'location']
+        if len(cols):
+            LTSS.__table__._columns.remove(cols[0])
+
+    @staticmethod
+    def db_container(image):
+        client = docker.from_env()
+        container = client.containers.run(image, ports={5432: None},
+                                          environment=["POSTGRES_HOST_AUTH_METHOD=trust"], detach=True,
+                                          auto_remove=True
+                                          )
+
+        start_time = time.time()
+
+        # because a newly created postgresql container (with empty data directory) will immediately restart,
+        # we have to wait for the second message to be sure postgres is ready for connections
+        while container.logs().count(b'database system is ready to accept connections') != 2:
+            if start_time + 30 <= time.time():  # timeout
+                raise RuntimeError("Container (or database) won't start.")
+
+            sleep(1)
+
+        # to refresh the port mapping
+        container.reload()
+        return container
+
+    @staticmethod
+    def ltss_init_wrapper(container, setup_timescaledb, setup_postgis):
+        return LTSS_DB(None, 'postgresql://postgres@localhost:' + container.ports['5432/tcp'][0]['HostPort'],
+                       123, setup_timescaledb, setup_postgis, lambda x: False)
+
+    def test_postgis_not_available(self):
+        container = self.db_container("postgres:latest")
+
+        try:
+            ltss = self.ltss_init_wrapper(container, False, True)
+            with pytest.raises(MissingExtensionError,
+                               match=r".*Postgis should be set up but extension is not available.*"):
+                ltss._setup_connection()
+        finally:
+            container.stop()
+
+    def test_timescaledb_not_available(self):
+        container = self.db_container("postgres:latest")
+
+        try:
+            ltss = self.ltss_init_wrapper(container, True, False)
+            with pytest.raises(MissingExtensionError,
+                               match=r".*TimescaleDB should be set up but extension is not available.*"):
+                ltss._setup_connection()
+
+        finally:
+            container.stop()
+
+    def test_lite(self):
+        container = self.db_container("postgres:latest")
+
+        try:
+            ltss = self.ltss_init_wrapper(container, False, False)
+            ltss._setup_connection()
+
+            with ltss.engine.connect() as con:
+                assert self._has_columns(con)
+                assert not self._has_location_column(con)
+        finally:
+            container.stop()
+
+    def test_timescaledb(self):
+        container = self.db_container("timescale/timescaledb:latest-pg14")
+
+        try:
+            ltss = self.ltss_init_wrapper(container, True, False)
+            ltss._setup_connection()
+
+            with ltss.engine.connect() as con:
+                assert self._is_hypertable(con)
+                assert self._has_columns(con)
+        finally:
+            container.stop()
+
+    def test_default_db(self):
+        # this is an old and outdated image but should be sufficient
+        container = self.db_container("timescale/timescaledb-postgis:latest-pg12")
+
+        try:
+            ltss = self.ltss_init_wrapper(container, True, True)
+            ltss._setup_connection()
+
+            with ltss.engine.connect() as con:
+                assert self._is_hypertable(con)
+                assert self._has_columns(con)
+                assert self._has_location_column(con)
+        finally:
+            container.stop()
+
+    @staticmethod
+    def _is_hypertable(con):
+        return 1 == con.execute(text(
+            f"SELECT * FROM timescaledb_information.hypertables "
+            f"WHERE hypertable_name = '{LTSS.__tablename__}'")).rowcount
+
+    @staticmethod
+    def _has_columns(con):
+        return 5 <= con.execute(text(f"SELECT COLUMN_NAME\
+        FROM information_schema.columns\
+        WHERE table_name = '{LTSS.__tablename__}'")).rowcount
+
+    @staticmethod
+    def _has_location_column(con):
+        return 1 == con.execute(text(f"SELECT *\
+        FROM information_schema.columns\
+        WHERE table_name = '{LTSS.__tablename__}'\
+        AND COLUMN_NAME = 'location'")).rowcount


### PR DESCRIPTION
Closes #20

Documentation is still missing because there might architectural changes (like renaming config parameters), but I'll add this after approval. ;)

There are four main things about this PR:
1) The model has been adjusted so that the location column (Postgis) can be dynamically activated (and is ignored otherwise).
2) Two config parameters have been added: `setup_timescaledb` and `setup_postgis` (default: True).
3) Depending on these parameters (and the database's abilities) `_setup_connection()` creates the table accordingly: either with the location column (Postgis) or without and either as hyptertable or not.
4) Some basic test cases have been added for this (requires docker for spinning up the different databases)

Both parameters are only considered when running the first time (i.e., when the table is created). Afterwards, they are ignored (and could be removed from the config file). Each time when connecting, it is independently determined whether the table is a hyptertable and whether the location column is available. E.g., this means, that one could create LTSS without the location column and later on add Postgis to the database (for another use-case) without any problems.
