### PR TITLE
added CI/CD via GitHub Actions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,0 +1,32 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python application
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.9"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r tests/requirements.txt
+    - name: Test with pytest
+      run: |
+         python -m pytest

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 docker==5.0.3
-GeoAlchemy2==0.10.2
-homeassistant==2022.2.6
+GeoAlchemy2==0.11.1
+homeassistant==2021.9.7
 psycopg2==2.9.3
-pytest-docker==0.10.3
-pytest==7.0.1
-SQLAlchemy==1.4.31
+pytest-docker==0.11.0
+pytest==7.1.1
+SQLAlchemy==1.4.32


### PR DESCRIPTION
Closes #30

So, apparently, it's very easy and I had to deal with it anyway. This is basically what Github suggested for Python packages but I removed flake8 and only included pytests. From here, it can gradually grow.

The requirements needed some adjustments (because Python's package handling sucks).