### PR TITLE
Remove id column

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,9 @@ dmypy.json
 # Cython debug symbols
 cython_debug/
 
+#MacOS
+.DS_Store
+
 # PyCharm
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ configuration.yaml
 
         ltss:
             db_url: postgresql://USER:PASSWORD@HOST_ADRESS/DB_NAME
-            chunk_time_interval: 2592000000000
+            chunk_time_interval: 604800000000
             include:
                 domains:
                 - sensor
@@ -66,7 +66,7 @@ configuration.yaml
 
         chunk_time_interval
         (int)(Optional)
-        The time interval to be used for chunking in TimescaleDB in microseconds. Defaults to 2592000000000 (30 days). Ignored for databases without TimescaleDB extension.
+        The time interval to be used for chunking in TimescaleDB in microseconds. Defaults to 604800000000 (7 days). Ignored for databases without TimescaleDB extension.
 
         exclude
         (map)(Optional)
@@ -103,14 +103,14 @@ configuration.yaml
 ## Details
 The states are stored in a single table ([hypertable](https://docs.timescale.com/latest/using-timescaledb/hypertables), when TimescaleDB is available) with the following layout:
 
-| Column name: | id | time | entity_id | state | attributes | location [PostGIS-only] |
-|:---|:---:|:---:|:---:|:---:|:---:|:-----------------------:|
-| Type: | bigint | timestamp with timezone | string | string | JSONB |       POINT(4326)       |
+| Column name: | time | entity_id | state | attributes | location [PostGIS-only] |
+|:---:|:---:|:---:|:---:|:---:|:-----------------------:|
+| Type: | timestamp with timezone | string | string | JSONB |       POINT(4326)       |
 | Primary key: | x | x |  |  |  |
-| Index: | x | x | x | x | x |                         |
+| Index: | x | x | x | x |                         |
 
 ### Only available with TimescaleDB:
-[Chunk size](https://docs.timescale.com/latest/using-timescaledb/hypertables#best-practices) of the hypertable is configurable using the `chunk_time_interval` config option. It defaults to 2592000000000 microseconds (30 days).
+[Chunk size](https://docs.timescale.com/latest/using-timescaledb/hypertables#best-practices) of the hypertable is configurable using the `chunk_time_interval` config option. It defaults to 604800000000 microseconds (7 days).
 
 ### Only available with PosttGIS:
 The location column is populated for those states where ```latitude``` and ```longitude``` is part of the state attributes.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ configuration.yaml
 
         ltss:
             db_url: postgresql://USER:PASSWORD@HOST_ADRESS/DB_NAME
-            chunk_time_interval: 604800000000
+            chunk_time_interval: 2592000000000
             include:
                 domains:
                 - sensor
@@ -66,7 +66,7 @@ configuration.yaml
 
         chunk_time_interval
         (int)(Optional)
-        The time interval to be used for chunking in TimescaleDB in microseconds. Defaults to 604800000000 (7 days). Ignored for databases without TimescaleDB extension.
+        The time interval to be used for chunking in TimescaleDB in microseconds. Defaults to 2592000000000 (30 days). Ignored for databases without TimescaleDB extension.
 
         exclude
         (map)(Optional)
@@ -110,7 +110,7 @@ The states are stored in a single table ([hypertable](https://docs.timescale.com
 | Index: | x | x | x | x |                         |
 
 ### Only available with TimescaleDB:
-[Chunk size](https://docs.timescale.com/latest/using-timescaledb/hypertables#best-practices) of the hypertable is configurable using the `chunk_time_interval` config option. It defaults to 604800000000 microseconds (7 days).
+[Chunk size](https://docs.timescale.com/latest/using-timescaledb/hypertables#best-practices) of the hypertable is configurable using the `chunk_time_interval` config option. It defaults to 2592000000000 microseconds (30 days).
 
 ### Only available with PosttGIS:
 The location column is populated for those states where ```latitude``` and ```longitude``` is part of the state attributes.

--- a/custom_components/ltss/__init__.py
+++ b/custom_components/ltss/__init__.py
@@ -57,7 +57,7 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Required(CONF_DB_URL): cv.string,
                 vol.Optional(
-                    CONF_CHUNK_TIME_INTERVAL, default=2592000000000
+                    CONF_CHUNK_TIME_INTERVAL, default=604800000000
                 ): cv.positive_int,  # 30 days
             }
         )

--- a/custom_components/ltss/__init__.py
+++ b/custom_components/ltss/__init__.py
@@ -57,7 +57,7 @@ CONFIG_SCHEMA = vol.Schema(
             {
                 vol.Required(CONF_DB_URL): cv.string,
                 vol.Optional(
-                    CONF_CHUNK_TIME_INTERVAL, default=604800000000
+                    CONF_CHUNK_TIME_INTERVAL, default=2592000000000
                 ): cv.positive_int,  # 30 days
             }
         )

--- a/custom_components/ltss/manifest.json
+++ b/custom_components/ltss/manifest.json
@@ -1,6 +1,6 @@
 {
   "domain": "ltss",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "name": "Long Time State Storage (LTSS)",
   "documentation": "https://github.com/freol35241/ltss",
   "requirements": [

--- a/custom_components/ltss/migrations.py
+++ b/custom_components/ltss/migrations.py
@@ -51,22 +51,7 @@ def check_and_migrate(engine):
         _LOGGER.warning(
             "Migrating you LTSS table to the latest schema, this might take a couple of minutes!"
         )
-        with engine.begin() as con:
-            con.execute(
-                text(
-                    f"""ALTER TABLE {LTSS.__tablename__}
-                        DROP CONSTRAINT {LTSS.__tablename__}_pkey CASCADE,
-                        ADD PRIMARY KEY(time,entity_id);"""
-                )
-            )
-            con.execute(
-                text(
-                    f"""ALTER TABLE {LTSS.__tablename__}
-                        DROP COLUMN id"""
-                )
-            )
-            con.commit()
-        _LOGGER.info("Migration completed successfully!")
+        remove_id_column(engine)
 
 
 def migrate_attributes_text_to_jsonb(engine):
@@ -97,3 +82,22 @@ def drop_entityid_index(engine):
                 autocommit=True
             )
         )
+
+
+def remove_id_column(engine):
+    with engine.begin() as con:
+        con.execute(
+            text(
+                f"""ALTER TABLE {LTSS.__tablename__}
+                    DROP CONSTRAINT {LTSS.__tablename__}_pkey CASCADE,
+                    ADD PRIMARY KEY(time,entity_id);"""
+            )
+        )
+        con.execute(
+            text(
+                f"""ALTER TABLE {LTSS.__tablename__}
+                    DROP COLUMN id"""
+            )
+        )
+        con.commit()
+    _LOGGER.info("Migration completed successfully!")

--- a/custom_components/ltss/migrations.py
+++ b/custom_components/ltss/migrations.py
@@ -46,6 +46,25 @@ def check_and_migrate(engine):
             _LOGGER.warning("Index on entity_id no longer needed, dropping...")
             drop_entityid_index(engine)
 
+    # id column?
+    if any(col["name"] == "id" for col in columns):
+        _LOGGER.warning(
+            "Migrating you LTSS table to the latest schema, this might take a couple of minutes!"
+        )
+        with engine.begin() as con:
+            con.execute(text(
+                    f"""ALTER TABLE {LTSS.__tablename__}
+                        DROP CONSTRAINT {LTSS.__tablename__}_pkey CASCADE,
+                        ADD PRIMARY KEY(time,entity_id);"""
+                )    
+            )
+            con.execute(text(
+                    f"""ALTER TABLE {LTSS.__tablename__}
+                        DROP COLUMN id"""
+                )    
+            )
+            con.commit()
+        _LOGGER.info('Migration completed successfully!')
 
 def migrate_attributes_text_to_jsonb(engine):
     with engine.connect() as con:

--- a/custom_components/ltss/migrations.py
+++ b/custom_components/ltss/migrations.py
@@ -52,19 +52,22 @@ def check_and_migrate(engine):
             "Migrating you LTSS table to the latest schema, this might take a couple of minutes!"
         )
         with engine.begin() as con:
-            con.execute(text(
+            con.execute(
+                text(
                     f"""ALTER TABLE {LTSS.__tablename__}
                         DROP CONSTRAINT {LTSS.__tablename__}_pkey CASCADE,
                         ADD PRIMARY KEY(time,entity_id);"""
-                )    
+                )
             )
-            con.execute(text(
+            con.execute(
+                text(
                     f"""ALTER TABLE {LTSS.__tablename__}
                         DROP COLUMN id"""
-                )    
+                )
             )
             con.commit()
-        _LOGGER.info('Migration completed successfully!')
+        _LOGGER.info("Migration completed successfully!")
+
 
 def migrate_attributes_text_to_jsonb(engine):
     with engine.connect() as con:

--- a/custom_components/ltss/models.py
+++ b/custom_components/ltss/models.py
@@ -28,7 +28,7 @@ class LTSS(Base):  # type: ignore
 
     __tablename__ = "ltss"
     time = Column(DateTime(timezone=True), default=datetime.utcnow, primary_key=True)
-    entity_id = Column(String(255),primary_key=True)
+    entity_id = Column(String(255), primary_key=True)
     state = Column(String(255), index=True)
     attributes = Column(JSONB)
     location = None  # when not activated, no location column will be added to the table/database

--- a/custom_components/ltss/models.py
+++ b/custom_components/ltss/models.py
@@ -27,9 +27,8 @@ class LTSS(Base):  # type: ignore
     """State change history."""
 
     __tablename__ = "ltss"
-    id = Column(BigInteger, primary_key=True, autoincrement=True)
     time = Column(DateTime(timezone=True), default=datetime.utcnow, primary_key=True)
-    entity_id = Column(String(255))
+    entity_id = Column(String(255),primary_key=True)
     state = Column(String(255), index=True)
     attributes = Column(JSONB)
     location = None  # when not activated, no location column will be added to the table/database

--- a/tests/pytest/test_databases.py
+++ b/tests/pytest/test_databases.py
@@ -128,7 +128,7 @@ class TestDBSetup:
     @staticmethod
     def _has_columns(con):
         return (
-            5
+            4
             <= con.execute(
                 text(
                     f"SELECT COLUMN_NAME\


### PR DESCRIPTION
 #25 

Includes the migration from the old primary keys to the new primary keys.
Removes the id column, since it is no longer tied to the primary key.