### PR TITLE
Handle 0x00 char. Catch any error in event handler loop

### DIFF
--- a/custom_components/ltss/__init__.py
+++ b/custom_components/ltss/__init__.py
@@ -228,6 +228,10 @@ class LTSS_DB(threading.Thread):
                 except exc.SQLAlchemyError:
                     updated = True
                     _LOGGER.exception("Error saving event: %s", event)
+                    
+                except:
+                    updated = True
+                    _LOGGER.exception("Error during saving event: %s", event)     
 
             if not updated:
                 _LOGGER.error(

--- a/custom_components/ltss/models.py
+++ b/custom_components/ltss/models.py
@@ -63,7 +63,7 @@ class LTSS(Base):  # type: ignore
         row = LTSS(
             entity_id=entity_id,
             time=event.time_fired,
-            state=state.state,
+            state=state.state.replace("\x00", "\uFFFD"),
             attributes=attrs,
             location=location,
         )


### PR DESCRIPTION
I had problems with a sensor sending 0x00 Char. I've  handled the 0x00 char by replacing them with \uFFFD which is this char:
![image](https://github.com/freol35241/ltss/assets/7011066/fa54798e-b4e0-4d8c-96db-45c54ac6975c).
I've also added a catch for any error in the event handling loop. If an unhandled error occurs in  this loop the whole integration stops working.
